### PR TITLE
Rename documentation to An Advanced Vector-Embedding Operations Toolkit and Cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# embkit
+# An Advanced Vector-Embedding Operations Toolkit and Cookbook
 
-CPU-only vector embedding toolkit with FAISS indexing, query ops, graph fusion, safety, calibration, and evaluation.
+An Advanced Vector-Embedding Operations Toolkit and Cookbook is a CPU-only vector embedding toolkit with FAISS indexing, query ops, graph fusion, safety, calibration, and evaluation.
 
 ## Setup
 ```bash
@@ -28,7 +28,7 @@ This will:
 
 ## Hugging Face encoder support (CPU-only)
 
-`embedding-kit` now ships with a factory that can spin up either the legacy
+An Advanced Vector-Embedding Operations Toolkit and Cookbook now ships with a factory that can spin up either the legacy
 deterministic `dummy-encoder` or a Hugging Face `sentence-transformers` model
 purely on CPU. The CLI keeps backward compatibility—existing configs that only
 specify `model.name: dummy-encoder` continue to work and still trigger the

--- a/architecture.md
+++ b/architecture.md
@@ -1,8 +1,8 @@
-# embkit Architecture
+# An Advanced Vector-Embedding Operations Toolkit and Cookbook Architecture
 
 ## 1. Intent
 
-Deliver a deterministic, CPU‑only toolkit for advanced vector retrieval. Provide core indexing, query algebra, graph fusion, safety, calibration, and evaluation with fast CLIs and unit tests. No network access. Float32 everywhere.
+Deliver An Advanced Vector-Embedding Operations Toolkit and Cookbook as a deterministic, CPU‑only toolkit for advanced vector retrieval. Provide core indexing, query algebra, graph fusion, safety, calibration, and evaluation with fast CLIs and unit tests. No network access. Float32 everywhere.
 
 ## 2. System boundary
 

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Complete demo showing embkit capabilities.
+Complete demo showing the capabilities of An Advanced Vector-Embedding Operations Toolkit and Cookbook.
 Runs a full pipeline and displays results.
 """
 

--- a/embkit/cli/eval.py
+++ b/embkit/cli/eval.py
@@ -7,7 +7,10 @@ from ..lib.utils import set_determinism, set_num_threads, read_jsonl
 from ..lib.eval.metrics import compute_all, expected_calibration_error, brier_score
 from ..lib.calibrate.temperature import temperature_fit, temperature_apply
 
-app = typer.Typer(no_args_is_help=True, help="embkit eval CLI")
+app = typer.Typer(
+    no_args_is_help=True,
+    help="An Advanced Vector-Embedding Operations Toolkit and Cookbook eval CLI",
+)
 
 @app.command("run")
 def run(config: str):

--- a/embkit/cli/index.py
+++ b/embkit/cli/index.py
@@ -16,7 +16,10 @@ from ..lib.utils.demo_data import generate_tiny
 from ..lib.index.flatip import FlatIP
 from ..lib.index.ivfpq import IVFPQ
 
-app = typer.Typer(no_args_is_help=True, help="embkit index CLI")
+app = typer.Typer(
+    no_args_is_help=True,
+    help="An Advanced Vector-Embedding Operations Toolkit and Cookbook index CLI",
+)
 
 @app.command("build")
 def build(config: str):

--- a/embkit/cli/search.py
+++ b/embkit/cli/search.py
@@ -11,7 +11,10 @@ from ..lib.query_ops import directional, mmr, contrastive
 from ..lib.safety.pii import pii_redact, pii_contains
 from ..lib.safety.repellors import apply_repellors
 
-app = typer.Typer(no_args_is_help=True, help="embkit search CLI")
+app = typer.Typer(
+    no_args_is_help=True,
+    help="An Advanced Vector-Embedding Operations Toolkit and Cookbook search CLI",
+)
 
 def _load_index(kind: str, path: str):
     p = os.path.join(path, "index")

--- a/implementation.md
+++ b/implementation.md
@@ -1,4 +1,4 @@
-# implementation.md — embkit
+# implementation.md — An Advanced Vector-Embedding Operations Toolkit and Cookbook
 
 This document is a complete, copy‑paste implementation guide. It includes file layout, code for every file, and commands to run. No external network calls. CPU‑only. Float32 everywhere. Deterministic.
 
@@ -1065,9 +1065,9 @@ if __name__ == "__main__":
 **README.md**
 
 ````md
-# embkit
+# An Advanced Vector-Embedding Operations Toolkit and Cookbook
 
-CPU-only vector embedding toolkit with FAISS indexing, query ops, graph fusion, safety, calibration, and evaluation.
+An Advanced Vector-Embedding Operations Toolkit and Cookbook is a CPU-only vector embedding toolkit with FAISS indexing, query ops, graph fusion, safety, calibration, and evaluation.
 
 ## Setup
 ```bash
@@ -1271,4 +1271,4 @@ make run EXP=demo
 * PII: regex covers emails, SSNs, common phones. Redaction occurs before output.
 * Calibration: temperature scaling minimizes NLL; `temperature_apply` outputs calibrated probabilities; ordering preserved.
 
-This document contains all code and guidance required to implement and run embkit end‑to‑end.
+This document contains all code and guidance required to implement and run An Advanced Vector-Embedding Operations Toolkit and Cookbook end‑to‑end.

--- a/requirements.md
+++ b/requirements.md
@@ -1,8 +1,8 @@
-# embkit Requirements
+# An Advanced Vector-Embedding Operations Toolkit and Cookbook Requirements
 
 ## 1. Purpose and Scope
 
-* The system **shall** implement a modular vector-embedding toolkit that goes beyond plain similarity search.
+* An Advanced Vector-Embedding Operations Toolkit and Cookbook **shall** implement a modular vector-embedding toolkit that goes beyond plain similarity search.
 * The toolkit **shall** include core models, FAISS indexing, query algebra operations, graph fusion, safety, calibration, evaluation, CLIs, tests, and a tiny quickstart dataset.
 * The v1 scope **shall** target single-host CPU, Python 3.11, float32 everywhere, and no internet calls.
 


### PR DESCRIPTION
## Summary
- rename the README introduction to use the new toolkit name
- update architecture and requirements documents to refer to An Advanced Vector-Embedding Operations Toolkit and Cookbook
- refresh CLI help strings, the demo description, and implementation guide snippets with the new name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68cc94520c1083218347cb84e358939c